### PR TITLE
(#03) Fixed Mobile Animations for Experience Section

### DIFF
--- a/src/Components/Experience/ExperienceBody.js
+++ b/src/Components/Experience/ExperienceBody.js
@@ -20,7 +20,7 @@ const ExperienceBody = (props) => {
     const experienceBodyTl = gsap.timeline({
       scrollTrigger: {
         trigger: experienceBodyRef,
-        start: "center bottom",
+        start: "top bottom",
       },
     });
 

--- a/src/Components/Experience/ExperiencesDisplay.js
+++ b/src/Components/Experience/ExperiencesDisplay.js
@@ -15,7 +15,7 @@ const ExperiencesDisplay = (props) => {
     const experienceDisplayTl = gsap.timeline({
       scrollTrigger: {
         trigger: experiencePathRef,
-        start: "center bottom",
+        start: "top bottom",
       },
     });
 


### PR DESCRIPTION
- Adjusted `start` property to now run the animation when the top experience body is in the viewport
- Start animation for non-mobile view is unchanged
- No adverse effects occur from this change